### PR TITLE
Swapt export assignment on types

### DIFF
--- a/Downloader.td.ts
+++ b/Downloader.td.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-export = Downloader;
+export default Downloader;
 
 
 interface DownloaderConfig{


### PR DESCRIPTION
Getting the following error on types when trying to run tsc against a project with this dependency:
```
node_modules/nodejs-file-downloader/Downloader.td.ts:2:1 - error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
```

Would modifying these types to use `export default` instead be acceptable?