### PR TITLE
Corrected https.request options parameter name

### DIFF
--- a/Download.js
+++ b/Download.js
@@ -225,10 +225,10 @@ module.exports = class Download {
             headers
         }
         if (httpsAgent) {
-            options.httpsAgent = httpsAgent;
+            options.agent = httpsAgent;
         }
         else if (proxy) {
-            options.httpsAgent = new HttpsProxyAgent(proxy)
+            options.agent = new HttpsProxyAgent(proxy)
         }
 
         const { makeRequestIter, cancel, } = makeRequest(url, options)


### PR DESCRIPTION
Options object passed to http.request / https.request methods do not have 'httpsAgent ' setting. Agent value should be passed under 'agent' key instead.

[https://nodejs.org/api/https.html#httpsrequesturl-options-callback](url)
[https://nodejs.org/api/http.html#httprequesturl-options-callback](url)