### PR TITLE
http has no default export member (typescript error 1192)

### DIFF
--- a/Downloader.td.ts
+++ b/Downloader.td.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import * as http from 'http';
 export default Downloader;
 
 


### PR DESCRIPTION
It looks like the target was to import "anything" inside "http" module as "http", instead of trying to import default on "http" module.

This screenshot shows the typescript error I receive :
![image](https://user-images.githubusercontent.com/55649705/155184277-00830489-1f6f-419c-b780-f71a36855d66.png)

As I did not want to turn on "skipLibCheck" on TypeScript, I forked the nodejs-file-downloader repository and made the patch.
I submit this pull request as it could have resolve any similar issue that I got. 

Though as I see the ``http`` import are only used for getting the ``IncomingMessage`` type, the import can be simplified into :
```typescript
// File: Downloader.td.ts
// Only import the type that we need
import { IncomingMessage } from 'http';

// and the onResponse@r parameter type can be changed into :
onResponse?(r: IncomingMessage):boolean|void
```

This typescript issue was produced in my environment:
- NodeJS version : v17.2.0
- TypeScript version : 4.5.2
- Operating System : Ubuntu 21.10
- nodejs-file-downloader version : 4.9.3
- ``@types/node`` version : 17.0.19
